### PR TITLE
Remove global build-options

### DIFF
--- a/com.github.fabiocolacio.marker.json
+++ b/com.github.fabiocolacio.marker.json
@@ -13,13 +13,6 @@
     "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
     "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
   ],
-  "build-options" : {
-    "cflags": "-O2 -g",
-    "cxxflags": "-O2 -g",
-    "env": {
-      "V": "1"
-    }
-  },
   "cleanup": ["/include", "/lib/pkgconfig",
     "/share/pkgconfig", "/share/aclocal",
     "/man", "/share/man", "/share/gtk-doc",


### PR DESCRIPTION
See for details: flathub/flathub#319

Though lemme check the build output first however. **Edit:** ah, I don’t know.