### PR TITLE
Add device=dri for fallback-x11 support

### DIFF
--- a/com.github.fabiocolacio.marker.json
+++ b/com.github.fabiocolacio.marker.json
@@ -6,7 +6,7 @@
   "command": "marker",
   "finish-args": [
     /* X11 + XShm access */
-    "--share=ipc", "--socket=fallback-x11",
+    "--share=ipc", "--socket=fallback-x11", "--device=dri",
     /* Render external images */
     "--share=network",
     /* Filesystem Access */


### PR DESCRIPTION
@bilelmoussaoui Found a bug. Guess that with all the changes in hardware acceleration, we now need this. Without dri, the preview-window remains blank.

![Screenshot from 2022-04-01 13-04-06](https://user-images.githubusercontent.com/33983090/161251999-ce984247-9b1a-4cd4-98c1-286ce126cf82.png)
