### PR TITLE
remove unneeded permissions

### DIFF
--- a/com.github.fabiocolacio.marker.json
+++ b/com.github.fabiocolacio.marker.json
@@ -9,8 +9,6 @@
     "--share=ipc", "--socket=fallback-x11", "--device=dri",
     /* Render external images */
     "--share=network",
-    /* Filesystem Access */
-    "--filesystem=home",
     /* Wayland access */
     "--socket=wayland",
     "--metadata=X-DConf=migrate-path=/com/github/fabiocolacio/marker/"


### PR DESCRIPTION
modern versions of gtk, such as what marker uses, provide built-in support for much of the xdg specification, notably in this case xdg-portal

therefore, the flatpak will work identically without --filesystem=home