### PR TITLE
Update GNOME runtime to version 46

### DIFF
--- a/0001-fix-Update-appdata-manifest-with-the-latest-release.patch
+++ b/0001-fix-Update-appdata-manifest-with-the-latest-release.patch
@@ -1,17 +1,47 @@
-From 6d5f33dbd79e8492268692b122eb95437b9ac934 Mon Sep 17 00:00:00 2001
-From: Camille019 <camille019@outlook.com>
-Date: Wed, 11 Oct 2023 15:26:03 +0200
-Subject: [PATCH] fix: Update appdata manifest with the latest release
+From 74459538c12645bb0ef4918285540f0e0f9614de Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Sat, 9 Nov 2024 14:13:01 +0300
+Subject: [PATCH] Fix appdata papercuts
 
+- Fix appdata issues.
 ---
- data/com.github.fabiocolacio.marker.appdata.xml | 13 +++++++++++++
- 1 file changed, 13 insertions(+)
+ data/com.github.fabiocolacio.marker.appdata.xml | 57 ++++++++++++++++++---------------------------------------
+ 1 file changed, 18 insertions(+), 39 deletions(-)
 
 diff --git a/data/com.github.fabiocolacio.marker.appdata.xml b/data/com.github.fabiocolacio.marker.appdata.xml
-index 28874374..2a31034c 100644
+index 2887437..87d184f 100644
 --- a/data/com.github.fabiocolacio.marker.appdata.xml
 +++ b/data/com.github.fabiocolacio.marker.appdata.xml
-@@ -60,6 +60,19 @@
+@@ -19,15 +19,7 @@
+       <li>Support for charter plots</li>
+       <li>Syntax highlighting for code blocks</li>
+       <li>Integrated sketch editor</li>
+-      <li>Exports to
+-        <ul>
+-          <li>PDF</li>
+-          <li>RTF</li>
+-          <li>ODT</li>
+-          <li>DOCx</li>
+-          <li>LaTeX</li>
+-        </ul>
+-      </li>
++      <li>Exports to PDF, RTF, ODT, DOCx, LaTeX</li>
+       <li>Custom CSS themes</li>
+       <li>Custom syntax themes</li>
+       <li>Figure captioning and numbering</li>
+@@ -51,15 +43,30 @@
+     </screenshot>
+   </screenshots>
+ 
++  <developer_name>Fábio Colácio</developer_name>
+   <url type="homepage">https://github.com/fabiocolacio/Marker</url>
+-  <project_group>Marker</project_group>
++  <url type="bugtracker">https://github.com/fabiocolacio/Marker/issues</url>
++  <url type="vcs-browser">https://github.com/fabiocolacio/Marker</url>
+ 
+   <provides>
+     <binary>marker</binary>
+     <id>com.github.fabiocolacio.marker</id>
    </provides>
  
    <releases>
@@ -31,6 +61,42 @@ index 28874374..2a31034c 100644
      <release version="2020.04.04" date="2020-04-04">
        <description>
          <ul>
--- 
-2.41.0
+@@ -107,34 +114,6 @@
+     </release>
+   </releases>
+ 
+- <content_rating type="oars-1.1">
+-    <content_attribute id="violence-cartoon">none</content_attribute>
+-    <content_attribute id="violence-fantasy">none</content_attribute>
+-    <content_attribute id="violence-realistic">none</content_attribute>
+-    <content_attribute id="violence-bloodshed">none</content_attribute>
+-    <content_attribute id="violence-sexual">none</content_attribute>
+-    <content_attribute id="violence-desecration">none</content_attribute>
+-    <content_attribute id="violence-slavery">none</content_attribute>
+-    <content_attribute id="violence-worship">none</content_attribute>
+-    <content_attribute id="drugs-alcohol">none</content_attribute>
+-    <content_attribute id="drugs-narcotics">none</content_attribute>
+-    <content_attribute id="drugs-tobacco">none</content_attribute>
+-    <content_attribute id="sex-nudity">none</content_attribute>
+-    <content_attribute id="sex-themes">none</content_attribute>
+-    <content_attribute id="sex-homosexuality">none</content_attribute>
+-    <content_attribute id="sex-prostitution">none</content_attribute>
+-    <content_attribute id="sex-adultery">none</content_attribute>
+-    <content_attribute id="sex-appearance">none</content_attribute>
+-    <content_attribute id="language-profanity">none</content_attribute>
+-    <content_attribute id="language-humor">none</content_attribute>
+-    <content_attribute id="language-discrimination">none</content_attribute>
+-    <content_attribute id="social-chat">none</content_attribute>
+-    <content_attribute id="social-info">none</content_attribute>
+-    <content_attribute id="social-audio">none</content_attribute>
+-    <content_attribute id="social-location">none</content_attribute>
+-    <content_attribute id="social-contacts">none</content_attribute>
+-    <content_attribute id="money-purchasing">none</content_attribute>
+-    <content_attribute id="money-gambling">none</content_attribute>
+-  </content_rating>
++ <content_rating type="oars-1.1"/>
+   
+ </component>
+--
+libgit2 1.7.2
 

--- a/com.github.fabiocolacio.marker.json
+++ b/com.github.fabiocolacio.marker.json
@@ -1,12 +1,14 @@
 {
   "app-id": "com.github.fabiocolacio.marker",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "45",
+  "runtime-version": "46",
   "sdk": "org.gnome.Sdk",
   "command": "marker",
   "finish-args": [
     /* X11 + XShm access */
-    "--share=ipc", "--socket=fallback-x11", "--device=dri",
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--device=dri",
     /* Render external images */
     "--share=network",
     /* Filesystem Access */
@@ -15,11 +17,18 @@
     "--socket=wayland",
     "--metadata=X-DConf=migrate-path=/com/github/fabiocolacio/marker/"
   ],
-  "cleanup": ["/include", "/lib/pkgconfig",
-    "/share/pkgconfig", "/share/aclocal",
-    "/man", "/share/man", "/share/gtk-doc",
-    "/share/vala",
-    "*.la", "*.a"],
+  "cleanup": [
+      "/include",
+      "/lib/pkgconfig",
+      "/share/pkgconfig",
+      "/share/aclocal",
+      "/man",
+      "/share/man",
+      "/share/gtk-doc",
+      "/share/vala",
+      "*.la",
+      "*.a"
+    ],
     "modules": [
       {
         "name": "enchant",
@@ -65,12 +74,6 @@
       {
         "name": "Marker",
         "buildsystem": "meson",
-        "post-install": [
-            "for size in 64 128; do
-              rsvg-convert -w $size -h $size -f png -o $size.png /app/share/icons/hicolor/scalable/apps/com.github.fabiocolacio.marker.svg
-              install -Dm644 $size.png /app/share/icons/hicolor/${size}x${size}/apps/com.github.fabiocolacio.marker.png
-            done"
-        ],
         "sources": [
           {
             "type": "git",
@@ -85,6 +88,9 @@
             "type": "patch",
             "path": "0001-fix-Update-appdata-manifest-with-the-latest-release.patch"
           }
+        ],
+        "post-install" : [
+            "find /app/share/icons/hicolor -type f -not -path \"*scalable*\" -not -path \"*actions*\" -name \"*.svg\" -delete"
         ]
       }
     ]


### PR DESCRIPTION
### Update GNOME runtime to version 46
- GNOME runtime version 45 has reached EOL.

### Fix appdata issues